### PR TITLE
Documentation fix for mgl-timeline-entry-dot usage in Angular 8,9,10

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ export class AppModule { }
         <mgl-timeline-entry-dot></mgl-timeline-entry-dot>
     </mgl-timeline-entry>
 </mgl-timeline>
+
+For Angular 8,9,10
+<mgl-timeline-entry-dot [size]="size" style="background-color: color;"></mgl-timeline-entry-dot>
 ```
 
 ### Include side data


### PR DESCRIPTION
According to current documentation description, `<mgl-timeline-entry-dot></mgl-timeline-entry-dot>` is not working for Angular 8,9,10

Modified Readme.md in "Include a dot" section for Angular 8,9,10 so developers can make timeline on higher version of Angular easily